### PR TITLE
[TASK] update FullKeepCnt

### DIFF
--- a/templates/config.pl
+++ b/templates/config.pl
@@ -461,7 +461,7 @@ $Conf{IncrPeriod} = 0.97;
 #    $Conf{FullKeepCnt} = 4;
 #    $Conf{FullKeepCnt} = [4];
 #
-$Conf{FullKeepCnt} = 52;
+$Conf{FullKeepCnt} = [4, 0, 12];
 
 #
 # Very old full backups are removed after $Conf{FullAgeMax} days.  However,
@@ -473,7 +473,7 @@ $Conf{FullKeepCnt} = 52;
 # full backups to exceed $Conf{FullAgeMax}.
 #
 $Conf{FullKeepCntMin} = 1;
-$Conf{FullAgeMax}     = 90;
+$Conf{FullAgeMax}     = 365;
 
 #
 # Number of incremental backups to keep.  Must be >= 1.


### PR DESCRIPTION
By now, we're keeping 52 weekly full backups. As we're running out of diskspace on our backup server, we decided to decrease the number of kept backups to 4 weeklies per month and 12 monthlies per year.